### PR TITLE
Scroll to the selected line

### DIFF
--- a/static/scripts/linenumber.js
+++ b/static/scripts/linenumber.js
@@ -19,6 +19,7 @@
             lines[i].id = lineId;
             if (lineId === anchorHash) {
                 lines[i].className += ' selected';
+                lines[i].scrollIntoView();
             }
         }
     }


### PR DESCRIPTION
As you see on <https://mochajs.org/api/mocha.js.html#line119>, line numbers do not exist until `linenumber.js` is fully initiated, so hash label is not working as intended.

Calling `scrollIntoView()` can fix this problem.