### PR TITLE
Use light color scheme on Mocha API document

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -358,14 +358,14 @@ footer {
   width: inherit;
   line-height: 18px;
   display: block;
-  background-color: #0d152a;
+  background-color: #f1efee;
   color: #aeaeae;
 }
 
 .prettyprint code {
   line-height: 18px;
   display: block;
-  background-color: #0d152a;
+  background-color: #f1efee;
   color: #4D4E53;
 }
 
@@ -398,11 +398,11 @@ footer {
 }
 
 .prettyprint.linenums li {
-   border-left: 3px #34446B solid;
+   border-left: 3px #b59076 solid;
 }
 
 .prettyprint.linenums li.selected, .prettyprint.linenums li.selected * {
-   background-color: #34446B;
+   background-color: #b59076;
 }
 
 .prettyprint.linenums li * {

--- a/static/styles/prettify.css
+++ b/static/styles/prettify.css
@@ -1,12 +1,77 @@
 /*! Color themes for Google Code Prettify | MIT License | github.com/jmblog/color-themes-for-google-code-prettify */
-.prettyprint {
-  background: #f1efee;
-  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
-  border: 0 !important;
-}
 
 .pln {
   color: #1b1918;
+}
+
+/* string content */
+.str {
+  color: #7b9726;
+}
+
+/* a keyword */
+.kwd {
+  color: #6666ea;
+}
+
+/* a comment */
+.com {
+  color: #9c9491;
+}
+
+/* a type name */
+.typ {
+  color: #407ee7;
+}
+
+/* a literal value */
+.lit {
+  color: #df5320;
+}
+
+/* punctuation */
+.pun {
+  color: #1b1918;
+}
+
+/* lisp open bracket */
+.opn {
+  color: #1b1918;
+}
+
+/* lisp close bracket */
+.clo {
+  color: #1b1918;
+}
+
+/* a markup tag name */
+.tag {
+  color: #f22c40;
+}
+
+/* a markup attribute name */
+.atn {
+  color: #df5320;
+}
+
+/* a markup attribute value */
+.atv {
+  color: #3d97b8;
+}
+
+/* a declaration */
+.dec {
+  color: #df5320;
+}
+
+/* a variable name */
+.var {
+  color: #f22c40;
+}
+
+/* a function name */
+.fun {
+  color: #407ee7;
 }
 
 /* Specify class=linenums on a pre to get line numbering */
@@ -14,106 +79,4 @@ ol.linenums {
   margin-top: 0;
   margin-bottom: 0;
   color: #9c9491;
-}
-
-li.L0,
-li.L1,
-li.L2,
-li.L3,
-li.L4,
-li.L5,
-li.L6,
-li.L7,
-li.L8,
-li.L9 {
-  padding-left: 1em;
-  background-color: #f1efee;
-  list-style-type: decimal;
-}
-
-@media screen {
-
-  /* string content */
-
-  .str {
-    color: #7b9726;
-  }
-
-  /* keyword */
-
-  .kwd {
-    color: #6666ea;
-  }
-
-  /* comment */
-
-  .com {
-    color: #9c9491;
-  }
-
-  /* type name */
-
-  .typ {
-    color: #407ee7;
-  }
-
-  /* literal value */
-
-  .lit {
-    color: #df5320;
-  }
-
-  /* punctuation */
-
-  .pun {
-    color: #1b1918;
-  }
-
-  /* lisp open bracket */
-
-  .opn {
-    color: #1b1918;
-  }
-
-  /* lisp close bracket */
-
-  .clo {
-    color: #1b1918;
-  }
-
-  /* markup tag name */
-
-  .tag {
-    color: #f22c40;
-  }
-
-  /* markup attribute name */
-
-  .atn {
-    color: #df5320;
-  }
-
-  /* markup attribute value */
-
-  .atv {
-    color: #3d97b8;
-  }
-
-  /* declaration */
-
-  .dec {
-    color: #df5320;
-  }
-
-  /* variable name */
-
-  .var {
-    color: #f22c40;
-  }
-
-  /* function name */
-
-  .fun {
-    color: #407ee7;
-  }
 }

--- a/static/styles/prettify.css
+++ b/static/styles/prettify.css
@@ -1,79 +1,119 @@
+/*! Color themes for Google Code Prettify | MIT License | github.com/jmblog/color-themes-for-google-code-prettify */
+.prettyprint {
+  background: #f1efee;
+  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, monospace;
+  border: 0 !important;
+}
+
 .pln {
-  color: #ddd;
-}
-
-/* string content */
-.str {
-  color: #61ce3c;
-}
-
-/* a keyword */
-.kwd {
-  color: #fbde2d;
-}
-
-/* a comment */
-.com {
-  color: #aeaeae;
-}
-
-/* a type name */
-.typ {
-  color: #8da6ce;
-}
-
-/* a literal value */
-.lit {
-  color: #fbde2d;
-}
-
-/* punctuation */
-.pun {
-  color: #ddd;
-}
-
-/* lisp open bracket */
-.opn {
-  color: #000000;
-}
-
-/* lisp close bracket */
-.clo {
-  color: #000000;
-}
-
-/* a markup tag name */
-.tag {
-  color: #8da6ce;
-}
-
-/* a markup attribute name */
-.atn {
-  color: #fbde2d;
-}
-
-/* a markup attribute value */
-.atv {
-  color: #ddd;
-}
-
-/* a declaration */
-.dec {
-  color: #EF5050;
-}
-
-/* a variable name */
-.var {
-  color: #c82829;
-}
-
-/* a function name */
-.fun {
-  color: #4271ae;
+  color: #1b1918;
 }
 
 /* Specify class=linenums on a pre to get line numbering */
 ol.linenums {
   margin-top: 0;
   margin-bottom: 0;
+  color: #9c9491;
+}
+
+li.L0,
+li.L1,
+li.L2,
+li.L3,
+li.L4,
+li.L5,
+li.L6,
+li.L7,
+li.L8,
+li.L9 {
+  padding-left: 1em;
+  background-color: #f1efee;
+  list-style-type: decimal;
+}
+
+@media screen {
+
+  /* string content */
+
+  .str {
+    color: #7b9726;
+  }
+
+  /* keyword */
+
+  .kwd {
+    color: #6666ea;
+  }
+
+  /* comment */
+
+  .com {
+    color: #9c9491;
+  }
+
+  /* type name */
+
+  .typ {
+    color: #407ee7;
+  }
+
+  /* literal value */
+
+  .lit {
+    color: #df5320;
+  }
+
+  /* punctuation */
+
+  .pun {
+    color: #1b1918;
+  }
+
+  /* lisp open bracket */
+
+  .opn {
+    color: #1b1918;
+  }
+
+  /* lisp close bracket */
+
+  .clo {
+    color: #1b1918;
+  }
+
+  /* markup tag name */
+
+  .tag {
+    color: #f22c40;
+  }
+
+  /* markup attribute name */
+
+  .atn {
+    color: #df5320;
+  }
+
+  /* markup attribute value */
+
+  .atv {
+    color: #3d97b8;
+  }
+
+  /* declaration */
+
+  .dec {
+    color: #df5320;
+  }
+
+  /* variable name */
+
+  .var {
+    color: #f22c40;
+  }
+
+  /* function name */
+
+  .fun {
+    color: #407ee7;
+  }
 }


### PR DESCRIPTION
### Description of the Change
According to [#3664](https://github.com/mochajs/mocha/issues/3664) issue, it is necessary to use a light background on Mocha API document.
So, I chose a `Atelier Forest Light` theme from [Google Code Prettify](https://github.com/google/code-prettify) and applied it as color scheme.

It can help colorblind people to read codes on the docs.

### As-is
![image](https://user-images.githubusercontent.com/44132406/66108189-03844f00-e5fd-11e9-82f3-86381c17c107.png)

### To-be
![image](https://user-images.githubusercontent.com/44132406/66107615-a2a84700-e5fb-11e9-9fb1-7699b70e3d6f.png)

Fix [#3664](https://github.com/mochajs/mocha/issues/3664)