### PR TITLE
Adjust white space for view on mobile

### DIFF
--- a/static/styles/jsdoc.css
+++ b/static/styles/jsdoc.css
@@ -654,7 +654,7 @@ html[data-search-mode] .level-hide {
 
   #main {
     width: 100%;
-    min-width: 360px;
+    min-width: 335px;
   }
 
   #main h1.page-title {


### PR DESCRIPTION
To fix [#4081](https://github.com/mochajs/mocha/issues/4081), I adjusted the min-width of `#main`.

I think this is more natural to see on mobile. It makes the white space like the examples below:
(The example device is a iPhone6/7/8 which width is 375px.)

### Home
![image](https://user-images.githubusercontent.com/44132406/67492626-a76b9280-f6b1-11e9-9bcf-8468d071bb81.png)

### Detail
![image](https://user-images.githubusercontent.com/44132406/67492679-c10cda00-f6b1-11e9-94c4-fc507ae3a198.png)
