### PR TITLE
use node 16 on netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,5 +4,5 @@ publish = "mocha/docs/_site/"
 
 [build.environment]
 DEBUG = "mocha:docs*"
-NODE_VERSION = "12"
-RUBY_VERSION = "2.7.1"
+NODE_VERSION = "16"
+RUBY_VERSION = "2.7.2"


### PR DESCRIPTION
Here, we're still using node 12 which will be OEF in a couple of months. 

So, setting node 16 for Netlify like mocha. 

And I've changed the default build image to Ubuntu Focal 20.04.